### PR TITLE
Fix small typos

### DIFF
--- a/R/data-encrypt.R
+++ b/R/data-encrypt.R
@@ -9,12 +9,12 @@
 #'
 #' Because the same \code{secret} is used for both encryption and decryption, symmetric
 #' encryption by itself is impractical for communication. For exchanging secure messages
-#' with other parties, use assymetric (public-key) methods (see \link{simple_encrypt} or
+#' with other parties, use asymmetric (public-key) methods (see \link{simple_encrypt} or
 #' \link{auth_encrypt}).
 #'
 #' The \code{nonce} is not confidential but required for decryption, and should be
 #' stored or sent along with the ciphertext. The purpose of the \code{nonce} is to
-#' randomize the cipher to protect gainst re-use attacks. This way you can use one
+#' randomize the cipher to protect against re-use attacks. This way you can use one
 #' and the same secret for encrypting multiple messages.
 #'
 #' The \link{data_tag} function generates an authenticated hash that can be stored

--- a/R/diffie-hellman.R
+++ b/R/diffie-hellman.R
@@ -11,7 +11,7 @@
 #' \href{https://en.wikipedia.org/wiki/Curve25519}{Curve25519}, a state-of-the-art Diffie-Hellman
 #' function suitable for a wide variety of applications.
 #'
-#' The method conists of two steps (see examples). First, both parties generate a random private
+#' The method consists of two steps (see examples). First, both parties generate a random private
 #' key and derive the corresponding public key using \link{pubkey}. These public keys are not
 #' confidential and can be exchanged over an insecure channel. After the public keys are exchanged,
 #' both parties will be able to calculate the (same) shared secret by combining his/her own private

--- a/R/keygen.R
+++ b/R/keygen.R
@@ -6,7 +6,7 @@
 #' Asymmetric methods rely on public-private keypairs. The private keys are secret and
 #' should never be shared with anyone. The public key on the other hand is not confidential
 #' and should be shared with the other parties. Public keys are typically published on the
-#' users's website or posted in public directories or keyservers.
+#' users' website or posted in public directories or keyservers.
 #'
 #' The two main applications for public key cryptography are encryption and authentication.
 #'

--- a/R/signatures.R
+++ b/R/signatures.R
@@ -16,7 +16,7 @@
 #' For confidential data, use authenticated encryption (\link{auth_encrypt})
 #' which allows for sending signed and encrypted messages in a single method.
 #'
-#' Currently sodium requires a different type of key pairfor signatures  (ed25519)
+#' Currently sodium requires a different type of key pair for signatures (ed25519)
 #' than for encryption (curve25519).
 #'
 #' @rdname sig

--- a/R/stream.R
+++ b/R/stream.R
@@ -9,7 +9,7 @@
 #' Random streams form the basis for most cryptographic methods. Based a shared secret
 #' (the key) we generate a predictable random data stream of equal length as the message
 #' we need to encrypt. Then we \link{xor} the message data with this random stream,
-#' which effectively inverts each byte in the message with probabiliy 0.5. The message
+#' which effectively inverts each byte in the message with probability 0.5. The message
 #' can be decrypted by re-generating exactly the same random data stream and \link{xor}'ing
 #' it back. See the examples.
 #'
@@ -17,7 +17,7 @@
 #' the same stream for decryption. The key forms the shared secret and should only known to
 #' the trusted parties. The \code{nonce} is not secret and should be stored or sent along
 #' with the ciphertext. The purpose of the \code{nonce} is to make a random stream unique
-#' to protect gainst re-use attacks. This way you can re-use a your key to encrypt multiple
+#' to protect against re-use attacks. This way you can re-use a your key to encrypt multiple
 #' messages, as long as you never re-use the same nonce.
 #'
 #' @export

--- a/man/diffie.Rd
+++ b/man/diffie.Rd
@@ -29,7 +29,7 @@ secret without ever exchanging the secret itself. Sodium implements
 \href{https://en.wikipedia.org/wiki/Curve25519}{Curve25519}, a state-of-the-art Diffie-Hellman
 function suitable for a wide variety of applications.
 
-The method conists of two steps (see examples). First, both parties generate a random private
+The method consists of two steps (see examples). First, both parties generate a random private
 key and derive the corresponding public key using \link{pubkey}. These public keys are not
 confidential and can be exchanged over an insecure channel. After the public keys are exchanged,
 both parties will be able to calculate the (same) shared secret by combining his/her own private

--- a/man/keygen.Rd
+++ b/man/keygen.Rd
@@ -23,7 +23,7 @@ public key.
 Asymmetric methods rely on public-private keypairs. The private keys are secret and
 should never be shared with anyone. The public key on the other hand is not confidential
 and should be shared with the other parties. Public keys are typically published on the
-users's website or posted in public directories or keyservers.
+users' website or posted in public directories or keyservers.
 
 The two main applications for public key cryptography are encryption and authentication.
 

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -46,7 +46,7 @@ process.
 For confidential data, use authenticated encryption (\link{auth_encrypt})
 which allows for sending signed and encrypted messages in a single method.
 
-Currently sodium requires a different type of key pairfor signatures  (ed25519)
+Currently sodium requires a different type of key pair for signatures (ed25519)
 than for encryption (curve25519).
 }
 \examples{

--- a/man/stream.Rd
+++ b/man/stream.Rd
@@ -35,7 +35,7 @@ use \link{data_encrypt}. For secure communication use \link{simple_encrypt} or
 Random streams form the basis for most cryptographic methods. Based a shared secret
 (the key) we generate a predictable random data stream of equal length as the message
 we need to encrypt. Then we \link{xor} the message data with this random stream,
-which effectively inverts each byte in the message with probabiliy 0.5. The message
+which effectively inverts each byte in the message with probability 0.5. The message
 can be decrypted by re-generating exactly the same random data stream and \link{xor}'ing
 it back. See the examples.
 
@@ -43,7 +43,7 @@ Each stream generator requires a \code{key} and a \code{nonce}. Both are require
 the same stream for decryption. The key forms the shared secret and should only known to
 the trusted parties. The \code{nonce} is not secret and should be stored or sent along
 with the ciphertext. The purpose of the \code{nonce} is to make a random stream unique
-to protect gainst re-use attacks. This way you can re-use a your key to encrypt multiple
+to protect against re-use attacks. This way you can re-use a your key to encrypt multiple
 messages, as long as you never re-use the same nonce.
 }
 \examples{

--- a/man/symmetric.Rd
+++ b/man/symmetric.Rd
@@ -33,12 +33,12 @@ used to encrypt local data on disk, or as a building block for more complex meth
 
 Because the same \code{secret} is used for both encryption and decryption, symmetric
 encryption by itself is impractical for communication. For exchanging secure messages
-with other parties, use assymetric (public-key) methods (see \link{simple_encrypt} or
+with other parties, use asymmetric (public-key) methods (see \link{simple_encrypt} or
 \link{auth_encrypt}).
 
 The \code{nonce} is not confidential but required for decryption, and should be
 stored or sent along with the ciphertext. The purpose of the \code{nonce} is to
-randomize the cipher to protect gainst re-use attacks. This way you can use one
+randomize the cipher to protect against re-use attacks. This way you can use one
 and the same secret for encrypting multiple messages.
 
 The \link{data_tag} function generates an authenticated hash that can be stored


### PR DESCRIPTION
Nothing more than one or two char typos here and there, e.g., `assymetric` - > `asymmetric`.